### PR TITLE
Feat: route, place api

### DIFF
--- a/src/main/java/com/backend/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/backend/domain/place/controller/PlaceController.java
@@ -1,14 +1,14 @@
 package com.backend.domain.place.controller;
 
 import com.backend.domain.place.dto.request.PlaceRecommendRequestDto;
+import com.backend.domain.place.dto.request.PlaceVisitRequestDto;
 import com.backend.domain.place.dto.response.PlaceRecommendResponseDto;
+import com.backend.domain.place.dto.response.PlaceVisitResponseDto;
 import com.backend.domain.place.service.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/place")
@@ -17,11 +17,19 @@ public class PlaceController {
 
     private final PlaceService placeService;
 
-    // 현재 위치 기반 관광지 추천 API
+    @Operation(description = "현재 위치 기반 관광지 추천 API")
     @GetMapping("/recommendation")
     public ResponseEntity<PlaceRecommendResponseDto> getPlace(@RequestBody PlaceRecommendRequestDto requestDto) {
 
         PlaceRecommendResponseDto responseDto = placeService.getPlace(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @Operation(description = "방문 완료 API")
+    @PostMapping("/visit")
+    public ResponseEntity<PlaceVisitResponseDto> visitPlace(@RequestBody PlaceVisitRequestDto requestDto) {
+
+        PlaceVisitResponseDto responseDto = placeService.visitPlace(requestDto);
         return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/backend/domain/place/dto/request/PlaceVisitRequestDto.java
+++ b/src/main/java/com/backend/domain/place/dto/request/PlaceVisitRequestDto.java
@@ -1,0 +1,11 @@
+package com.backend.domain.place.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PlaceVisitRequestDto(
+        @Schema(description = "경도")
+        String mapX,
+        @Schema(description = "위도")
+        String mapY
+) {
+}

--- a/src/main/java/com/backend/domain/place/dto/response/PlaceVisitResponseDto.java
+++ b/src/main/java/com/backend/domain/place/dto/response/PlaceVisitResponseDto.java
@@ -1,0 +1,9 @@
+package com.backend.domain.place.dto.response;
+
+public record PlaceVisitResponseDto(
+        String placeName,
+        String date,
+        String time,
+        String image
+) {
+}

--- a/src/main/java/com/backend/domain/place/entity/Place.java
+++ b/src/main/java/com/backend/domain/place/entity/Place.java
@@ -29,15 +29,21 @@ public class Place extends BaseEntity {
 
     private String address;
 
+    private String mapX;
+
+    private String mapY;
+
     @Column(name = "visit_date")
     private LocalDateTime visitDate;
 
     @Builder
-    public Place(String name, PlaceType placeType, String imageUrl, String address) {
+    public Place(String name, PlaceType placeType, String imageUrl, String address, String mapX, String mapY) {
 
         this.name = name;
         this.placeType = placeType;
         this.imageUrl = imageUrl;
         this.address = address;
+        this.mapX = mapX;
+        this.mapY = mapY;
     }
 }

--- a/src/main/java/com/backend/domain/place/service/PlaceService.java
+++ b/src/main/java/com/backend/domain/place/service/PlaceService.java
@@ -18,6 +18,7 @@ import com.backend.domain.route.repository.RouteRepository;
 import com.backend.domain.routePlace.entity.RoutePlace;
 import com.backend.domain.routePlace.repository.RoutePlaceRepository;
 import com.backend.global.security.util.MemberUtil;
+import com.backend.global.util.FormatUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,7 @@ public class PlaceService {
     private final RoutePlaceRepository routePlaceRepository;
 
     private final MemberUtil memberUtil;
+    private final FormatUtil formatUtil;
 
     @Transactional
     public PlaceVisitResponseDto visitPlace(PlaceVisitRequestDto requestDto) {
@@ -59,8 +61,8 @@ public class PlaceService {
         saveRoutePlaceMapping(route, place);
 
         LocalDateTime now = LocalDateTime.now();
-        String formattedDate = formatDate(now);
-        String formattedTime = formatTime(now);
+        String formattedDate = formatUtil.formatDate(now);
+        String formattedTime = formatUtil.formatTime(now);
 
         return new PlaceVisitResponseDto(place.getName(), formattedDate, formattedTime, place.getImageUrl());
     }
@@ -83,14 +85,6 @@ public class PlaceService {
                 .place(place)
                 .build();
         routePlaceRepository.save(routePlace);
-    }
-
-    private String formatDate(LocalDateTime dateTime) {
-        return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
-    }
-
-    private String formatTime(LocalDateTime dateTime) {
-        return dateTime.format(DateTimeFormatter.ofPattern("HH:mm"));
     }
 
     private boolean isWithinRange(String targetX, String targetY, String currentX, String currentY) {

--- a/src/main/java/com/backend/domain/place/service/PlaceService.java
+++ b/src/main/java/com/backend/domain/place/service/PlaceService.java
@@ -1,14 +1,22 @@
 package com.backend.domain.place.service;
 
 import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Random;
 
 import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.repository.MemberRepository;
 import com.backend.domain.place.dto.request.PlaceRecommendRequestDto;
+import com.backend.domain.place.dto.request.PlaceVisitRequestDto;
 import com.backend.domain.place.dto.response.PlaceRecommendResponseDto;
+import com.backend.domain.place.dto.response.PlaceVisitResponseDto;
 import com.backend.domain.place.entity.Place;
 import com.backend.domain.place.repository.PlaceRepository;
+import com.backend.domain.route.entity.Route;
+import com.backend.domain.route.repository.RouteRepository;
+import com.backend.domain.routePlace.entity.RoutePlace;
+import com.backend.domain.routePlace.repository.RoutePlaceRepository;
 import com.backend.global.security.util.MemberUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,8 +37,78 @@ public class PlaceService {
 
     private final PlaceRepository placeRepository;
     private final MemberRepository memberRepository;
+    private final RouteRepository routeRepository;
+    private final RoutePlaceRepository routePlaceRepository;
 
     private final MemberUtil memberUtil;
+
+    @Transactional
+    public PlaceVisitResponseDto visitPlace(PlaceVisitRequestDto requestDto) {
+        Long memberId = memberUtil.getCurrentMemberId();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("해당 회원 없음"));
+
+        Place place = placeRepository.findById(member.getRecentPlaceId())
+                .orElseThrow(() -> new RuntimeException("해당 장소 없음"));
+
+        if (!isWithinRange(place.getMapX(), place.getMapY(), requestDto.mapX(), requestDto.mapY())) {
+            throw new IllegalArgumentException("아직 도착하지 않았습니다.");
+        }
+
+        Route route = getOrCreateTodayRoute(member);
+        saveRoutePlaceMapping(route, place);
+
+        LocalDateTime now = LocalDateTime.now();
+        String formattedDate = formatDate(now);
+        String formattedTime = formatTime(now);
+
+        return new PlaceVisitResponseDto(place.getName(), formattedDate, formattedTime, place.getImageUrl());
+    }
+
+    private Route getOrCreateTodayRoute(Member member) {
+        String today = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        return routeRepository.findByNameAndMember(today, member)
+                .orElseGet(() -> {
+                    Route newRoute = Route.builder()
+                            .name(today)
+                            .member(member)
+                            .build();
+                    return routeRepository.save(newRoute);
+                });
+    }
+
+    private void saveRoutePlaceMapping(Route route, Place place) {
+        RoutePlace routePlace = RoutePlace.builder()
+                .route(route)
+                .place(place)
+                .build();
+        routePlaceRepository.save(routePlace);
+    }
+
+    private String formatDate(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    }
+
+    private String formatTime(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("HH:mm"));
+    }
+
+    private boolean isWithinRange(String targetX, String targetY, String currentX, String currentY) {
+        try {
+            double targetXd = Double.parseDouble(targetX);
+            double targetYd = Double.parseDouble(targetY);
+            double currentXd = Double.parseDouble(currentX);
+            double currentYd = Double.parseDouble(currentY);
+
+            double tolerance = 0.0005;
+
+            return Math.abs(targetXd - currentXd) <= tolerance &&
+                    Math.abs(targetYd - currentYd) <= tolerance;
+
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
 
     @Transactional
     public PlaceRecommendResponseDto getPlace(PlaceRecommendRequestDto requestDto) {
@@ -50,6 +128,8 @@ public class PlaceService {
             String placeName = selectedItem.path("title").asText();
             String address = selectedItem.path("addr1").asText();
             String imageUrl = selectedItem.path("firstimage").asText();
+            String mapX = selectedItem.path("mapx").asText();
+            String mapY = selectedItem.path("mapy").asText();
 
             // Place 저장 또는 조회
             Place place = placeRepository.findByName(placeName)
@@ -59,6 +139,8 @@ public class PlaceService {
                                     .placeType(requestDto.placeType())
                                     .imageUrl(imageUrl)
                                     .address(address)
+                                    .mapX(mapX)
+                                    .mapY(mapY)
                                     .build()
                     ));
 

--- a/src/main/java/com/backend/domain/route/controller/RouteController.java
+++ b/src/main/java/com/backend/domain/route/controller/RouteController.java
@@ -1,0 +1,26 @@
+package com.backend.domain.route.controller;
+
+import com.backend.domain.route.dto.response.TodayRouteResponse;
+import com.backend.domain.route.service.RouteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/route")
+public class RouteController {
+
+    private final RouteService routeService;
+
+    @GetMapping("/today")
+    public ResponseEntity<List<TodayRouteResponse>> getTodayRoute() {
+
+        List<TodayRouteResponse> responses = routeService.getTodayRoute();
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/src/main/java/com/backend/domain/route/controller/RouteController.java
+++ b/src/main/java/com/backend/domain/route/controller/RouteController.java
@@ -1,7 +1,10 @@
 package com.backend.domain.route.controller;
 
-import com.backend.domain.route.dto.response.TodayRouteResponse;
+import com.backend.domain.place.dto.response.PlaceVisitResponseDto;
+import com.backend.domain.route.dto.response.RouteAllResponseDto;
+import com.backend.domain.route.dto.response.RoutePreviewResponse;
 import com.backend.domain.route.service.RouteService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,10 +20,27 @@ public class RouteController {
 
     private final RouteService routeService;
 
+    @Operation(description = "[메인 페이지] 오늘 루트 조회하는 API")
     @GetMapping("/today")
-    public ResponseEntity<List<TodayRouteResponse>> getTodayRoute() {
+    public ResponseEntity<List<RoutePreviewResponse>> getTodayRoute() {
 
-        List<TodayRouteResponse> responses = routeService.getTodayRoute();
+        List<RoutePreviewResponse> responses = routeService.getTodayRoute();
         return ResponseEntity.ok(responses);
+    }
+
+    @Operation(description = "[마이 페이지] 전체 방문 루트 조회하는 API")
+    @GetMapping("/all")
+    public ResponseEntity<List<RouteAllResponseDto>> getAllRoute() {
+
+        List<RouteAllResponseDto> responseDtos = routeService.getAllRoute();
+        return ResponseEntity.ok(responseDtos);
+    }
+
+    @Operation(description = "[마이 페이지] 전체 추천지 카드 조회하는 API")
+    @GetMapping("/card")
+    public ResponseEntity<List<PlaceVisitResponseDto>> getAllCard() {
+
+        List<PlaceVisitResponseDto> responseDtos = routeService.getAllCard();
+        return ResponseEntity.ok(responseDtos);
     }
 }

--- a/src/main/java/com/backend/domain/route/dto/response/RouteAllResponseDto.java
+++ b/src/main/java/com/backend/domain/route/dto/response/RouteAllResponseDto.java
@@ -1,0 +1,10 @@
+package com.backend.domain.route.dto.response;
+
+import java.util.List;
+
+public record RouteAllResponseDto(
+
+        String date,
+        List<RoutePreviewResponse> routes
+) {
+}

--- a/src/main/java/com/backend/domain/route/dto/response/RoutePreviewResponse.java
+++ b/src/main/java/com/backend/domain/route/dto/response/RoutePreviewResponse.java
@@ -1,8 +1,6 @@
 package com.backend.domain.route.dto.response;
 
-import java.util.List;
-
-public record TodayRouteResponse(
+public record RoutePreviewResponse(
         String name,
         String image
 ) {

--- a/src/main/java/com/backend/domain/route/dto/response/TodayRouteResponse.java
+++ b/src/main/java/com/backend/domain/route/dto/response/TodayRouteResponse.java
@@ -1,0 +1,9 @@
+package com.backend.domain.route.dto.response;
+
+import java.util.List;
+
+public record TodayRouteResponse(
+        String name,
+        String image
+) {
+}

--- a/src/main/java/com/backend/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/backend/domain/route/repository/RouteRepository.java
@@ -3,9 +3,13 @@ package com.backend.domain.route.repository;
 import com.backend.domain.member.entity.Member;
 import com.backend.domain.route.entity.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
 
     Optional<Route> findByNameAndMember(String name, Member member);
+
+    List<Route> findByMemberOrderByCreatedAtDesc(Member member);
 }

--- a/src/main/java/com/backend/domain/route/service/RouteService.java
+++ b/src/main/java/com/backend/domain/route/service/RouteService.java
@@ -1,0 +1,56 @@
+package com.backend.domain.route.service;
+
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.route.dto.response.TodayRouteResponse;
+import com.backend.domain.route.entity.Route;
+import com.backend.domain.route.repository.RouteRepository;
+import com.backend.domain.routePlace.entity.RoutePlace;
+import com.backend.domain.routePlace.repository.RoutePlaceRepository;
+import com.backend.global.security.util.MemberUtil;
+import com.backend.global.util.FormatUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RouteService {
+
+    private final RouteRepository routeRepository;
+    private final MemberRepository memberRepository;
+    private final RoutePlaceRepository routePlaceRepository;
+
+    private final FormatUtil formatUtil;
+    private final MemberUtil memberUtil;
+
+    public List<TodayRouteResponse> getTodayRoute() {
+
+        Long memberId = memberUtil.getCurrentMemberId();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("해당 회원 없음"));
+
+        // 오늘 Route 가져오기
+        String formattedDate = formatUtil.formatDate(LocalDateTime.now());
+        Route route = routeRepository.findByNameAndMember(formattedDate, member)
+                .orElse(null);
+
+        List<TodayRouteResponse> responses = new ArrayList<>();
+        if (route != null) {
+
+            List<RoutePlace> routePlaces = routePlaceRepository.findByRouteOrderByCreatedAtAsc(route);
+            for (RoutePlace routePlace : routePlaces) {
+
+                TodayRouteResponse response = new TodayRouteResponse(
+                        routePlace.getPlace().getName(),
+                        routePlace.getPlace().getImageUrl()
+                );
+                responses.add(response);
+            }
+        }
+        return responses;
+    }
+}

--- a/src/main/java/com/backend/domain/routePlace/repository/RoutePlaceRepository.java
+++ b/src/main/java/com/backend/domain/routePlace/repository/RoutePlaceRepository.java
@@ -1,7 +1,12 @@
 package com.backend.domain.routePlace.repository;
 
+import com.backend.domain.route.entity.Route;
 import com.backend.domain.routePlace.entity.RoutePlace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RoutePlaceRepository extends JpaRepository<RoutePlace, Long> {
+
+    List<RoutePlace> findByRouteOrderByCreatedAtAsc(Route route);
 }

--- a/src/main/java/com/backend/global/util/FormatUtil.java
+++ b/src/main/java/com/backend/global/util/FormatUtil.java
@@ -1,0 +1,18 @@
+package com.backend.global.util;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class FormatUtil {
+
+    public String formatDate(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    }
+
+    public String formatTime(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("HH:mm"));
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> `close #이슈번호` 또는 `resolve #이슈번호`를 통해 자동 닫힘 처리 가능

예: `Closes #123`

---

## ✨ 변경 사항
> 어떤 작업을 했는지 간단히 요약해 주세요.

- 목적지 방문 완료 API
- [메인 페이지] 오늘 일정 루트 조회하는 API
- [마이 페이지] 전체 추천지 카드 조회하는 API
- [마이 페이지] 전체 일정 루트 조회하는 API


---

## ✅ 작업 내용 체크리스트
- [ ] 테스트 완료
- [ ] Issue 연결되었는지 확인
- [ ] merge할 브랜치 위치 확인
- [ ] Label 지정했는지 확인
- [ ] Squash and Merge 옵션 확인

---

## 💬 추가 참고 사항
> 리뷰어가 참고하면 좋을 만한 내용을 자유롭게 작성해 주세요.